### PR TITLE
enable tool support

### DIFF
--- a/llm_deepseek.py
+++ b/llm_deepseek.py
@@ -15,15 +15,28 @@ MODELS = (
     "deepseek-reasoner",
 )
 
+MODEL_PARAMS = {
+    "deepseek-chat": dict(
+        supports_tools=True,
+    ),
+    "deepseek-coder": dict(
+        supports_tools=True,
+    ),
+    "deepseek-reasoner": dict(
+        supports_tools=True,
+    ),
+}
+
 
 class DeepSeekChat(Chat):
     needs_key = "deepseek"
     key_env_var = "LLM_DEEPSEEK_KEY"
 
-    def __init__(self, model_name):
+    def __init__(self, model_name, supports_tools):
         super().__init__(
             model_name=model_name,
             model_id=model_name,
+            supports_tools=supports_tools,
             api_base="https://api.deepseek.com",
         )
 
@@ -38,10 +51,11 @@ if HAS_ASYNC:
         needs_key = "deepseek"
         key_env_var = "LLM_DEEPSEEK_KEY"
 
-        def __init__(self, model_name):
+        def __init__(self, model_name, supports_tools):
             super().__init__(
                 model_name=model_name,
                 model_id=model_name,
+                supports_tools=supports_tools,
                 api_base="https://api.deepseek.com",
             )
 
@@ -56,10 +70,14 @@ def register_models(register):
     if not key:
         return
     for model_id in MODELS:
+        kwargs = dict(
+            model_name=model_id,
+            supports_tools=MODEL_PARAMS.get(model_id, {}).get('supports_tools', False),
+        )
         if HAS_ASYNC:
             register(
-                DeepSeekChat(model_id),
-                DeepSeekAsyncChat(model_id),
+                DeepSeekChat(**kwargs),
+                DeepSeekAsyncChat(**kwargs),
             )
         else:
-            register(DeepSeekChat(model_id))
+            register(DeepSeekChat(**kwargs))


### PR DESCRIPTION
All models support tool calling, but this info isn't available in the `https://api.deepseek.com/models` API so hard-code it for now

```
$ llm models list -q deepseek --options
DeepSeek: deepseek-coder
  Options:
    temperature: float
    max_tokens: int
    top_p: float
    frequency_penalty: float
    presence_penalty: float
    stop: str
    logit_bias: dict, str
    seed: int
    json_object: boolean
  Features:
  - streaming
  - tools
  - async
  Keys:
    key: deepseek
    env_var: LLM_DEEPSEEK_KEY
DeepSeek: deepseek-reasoner
  Options:
    temperature: float
    max_tokens: int
    top_p: float
    frequency_penalty: float
    presence_penalty: float
    stop: str
    logit_bias: dict, str
    seed: int
    json_object: boolean
  Features:
  - streaming
  - tools
  - async
  Keys:
    key: deepseek
    env_var: LLM_DEEPSEEK_KEY
```

```
$ llm -m deepseek-chat --tool llm_version "What version of LLM is this?" --td

Tool call: llm_version({})
  0.26

The installed version of LLM is 0.26.
```