### PR TITLE
Add DeepSeek v4 models and options support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ Run prompts like this:
 llm -m deepseek-chat 'five great names for a pet ocelot'
 llm -m deepseek-reasoner 'solve \\int \\frac{\\ln(x)\\arctan(x)}{x^2+1} dx'
 llm -m deepseek-coder 'how to reverse a linked list in python'
+llm -m deepseek-v4-flash 'summarize the benefits of unit tests'
+llm -m deepseek-v4-pro 'explain how vector databases work'
+```
+
+DeepSeek models support the standard OpenAI-compatible options such as
+`max_tokens`, `top_p`, `stop`, and `json_object`, plus DeepSeek-specific
+options:
+
+```bash
+llm -m deepseek-v4-pro 'write a haiku about databases' \
+  -o temperature 0.7 \
+  -o thinking enabled \
+  -o reasoning_effort xhigh
 ```
 
 ## Development

--- a/llm_deepseek.py
+++ b/llm_deepseek.py
@@ -1,5 +1,8 @@
+from typing import Literal, Optional
+
 import llm
 from llm.default_plugins.openai_models import Chat
+from pydantic import Field
 
 # Try to import AsyncChat, but don't fail if it's not available
 try:
@@ -13,10 +16,40 @@ MODELS = (
     "deepseek-chat",
     "deepseek-coder",
     "deepseek-reasoner",
+    "deepseek-v4-flash",
+    "deepseek-v4-pro",
 )
 
 
-class DeepSeekChat(Chat):
+class DeepSeekOptions(Chat.Options):
+    temperature: Optional[float] = Field(
+        description="Sampling temperature to use, between 0 and 2.",
+        ge=0,
+        le=2,
+        default=None,
+    )
+    thinking: Optional[Literal["enabled", "disabled"]] = Field(
+        description="DeepSeek thinking mode type, sent as thinking.type.",
+        default=None,
+    )
+    reasoning_effort: Optional[Literal["low", "medium", "high", "xhigh", "max"]] = Field(
+        description="Constrains effort on reasoning for supported DeepSeek models.",
+        default=None,
+    )
+
+
+class DeepSeekMixin:
+    Options = DeepSeekOptions
+
+    def build_kwargs(self, prompt, stream):
+        kwargs = super().build_kwargs(prompt, stream)
+        thinking_type = kwargs.pop("thinking", None)
+        if thinking_type is not None:
+            kwargs.setdefault("extra_body", {})["thinking"] = {"type": thinking_type}
+        return kwargs
+
+
+class DeepSeekChat(DeepSeekMixin, Chat):
     needs_key = "deepseek"
     key_env_var = "LLM_DEEPSEEK_KEY"
 
@@ -34,7 +67,7 @@ class DeepSeekChat(Chat):
 # Only define AsyncChat class if async support is available
 if HAS_ASYNC:
 
-    class DeepSeekAsyncChat(AsyncChat):
+    class DeepSeekAsyncChat(DeepSeekMixin, AsyncChat):
         needs_key = "deepseek"
         key_env_var = "LLM_DEEPSEEK_KEY"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License"
 ]
 dependencies = [
-    "llm"
+    "llm",
+    "pydantic",
 ]
 
 [project.urls]

--- a/tests/test_deepseek.py
+++ b/tests/test_deepseek.py
@@ -1,4 +1,9 @@
+import llm
+import pytest
 from llm.plugins import pm
+
+import llm_deepseek
+
 
 def test_plugin_is_installed():
     try:
@@ -6,6 +11,82 @@ def test_plugin_is_installed():
         load_plugins()
     except ImportError:
         pass
-        
+
     names = [mod.__name__ for mod in pm.get_plugins()]
     assert "llm_deepseek" in names
+
+
+def test_models_include_deepseek_v4_models():
+    assert "deepseek-v4-flash" in llm_deepseek.MODELS
+    assert "deepseek-v4-pro" in llm_deepseek.MODELS
+
+
+def test_register_models_requires_api_key(monkeypatch):
+    monkeypatch.setattr(llm_deepseek.llm, "get_key", lambda *args: None)
+    registered_model_ids = []
+
+    def register(*models):
+        registered_model_ids.append(models[0].model_id)
+
+    llm_deepseek.register_models(register)
+
+    assert registered_model_ids == []
+
+
+def test_register_models_registers_all_models_with_api_key(monkeypatch):
+    monkeypatch.setattr(llm_deepseek.llm, "get_key", lambda *args: "fake-key")
+    registered_model_ids = []
+
+    def register(*models):
+        registered_model_ids.append(models[0].model_id)
+
+    llm_deepseek.register_models(register)
+
+    assert registered_model_ids == list(llm_deepseek.MODELS)
+
+
+def test_deepseek_options_build_request_kwargs():
+    model = llm_deepseek.DeepSeekChat("deepseek-v4-pro")
+    prompt = llm.Prompt(
+        "hello",
+        model,
+        options=model.Options(
+            temperature=0.4,
+            thinking="enabled",
+            reasoning_effort="xhigh",
+        ),
+    )
+
+    assert model.build_kwargs(prompt, stream=False) == {
+        "temperature": 0.4,
+        "reasoning_effort": "xhigh",
+        "extra_body": {"thinking": {"type": "enabled"}},
+    }
+
+
+def test_deepseek_options_preserve_openai_compatible_options():
+    model = llm_deepseek.DeepSeekChat("deepseek-chat")
+    prompt = llm.Prompt(
+        "hello",
+        model,
+        options=model.Options(
+            max_tokens=100,
+            top_p=0.8,
+            stop="END",
+            json_object=True,
+        ),
+    )
+
+    assert model.build_kwargs(prompt, stream=False) == {
+        "max_tokens": 100,
+        "top_p": 0.8,
+        "stop": "END",
+        "response_format": {"type": "json_object"},
+    }
+
+
+def test_deepseek_options_reject_invalid_thinking_type():
+    model = llm_deepseek.DeepSeekChat("deepseek-v4-flash")
+
+    with pytest.raises(ValueError):
+        model.Options(thinking="maybe")


### PR DESCRIPTION
  - Add `deepseek-v4-flash` and `deepseek-v4-pro` to the registered model list.
  - Add DeepSeek-specific options for `thinking` and `reasoning_effort`.
  - Document the new models and options in the README.