### PR TITLE
fix deepseek model name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ Run `llm models` to get a list of models.
 
 Run prompts like this:
 ```bash
-llm -m deepseek-chat 'five great names for a pet ocelot'
-llm -m deepseek-reasoner 'solve \\int \\frac{\\ln(x)\\arctan(x)}{x^2+1} dx'
-llm -m deepseek-coder 'how to reverse a linked list in python'
+llm -m deepseek-v4-pro 'five great names for a pet ocelot'
+llm -m deepseek-v4-flash 'how to reverse a linked list in python'
 ```
 
 ## Development

--- a/llm_deepseek.py
+++ b/llm_deepseek.py
@@ -10,9 +10,8 @@ except ImportError:
     HAS_ASYNC = False
 
 MODELS = (
-    "deepseek-chat",
-    "deepseek-coder",
-    "deepseek-reasoner",
+    "deepseek-v4-pro",
+    "deepseek-v4-flash",
 )
 
 


### PR DESCRIPTION
The old model name `deepseek-chat` `deepseek-reasoner` and `deepseek-coder` is deprecated.
Use `deepseek-v4-pro` and `deepseek-v4-flash` instead.